### PR TITLE
PORTAL: Change Params of queues table to text to admit longer params

### DIFF
--- a/html/portal/modules/Agoraportal/lib/Agoraportal/Installer.php
+++ b/html/portal/modules/Agoraportal/lib/Agoraportal/Installer.php
@@ -220,7 +220,9 @@ class Agoraportal_Installer extends Zikula_AbstractInstaller {
                 $this->setVar('createDB', false)
                         ->setVar('URLNodesModelBase', 'http://pwc-int.educacio.intranet/agora/master')
                         ->setVar('DBNodesModel', 'usu6, usu7, usu8, usu9, usu10');
-
+            case '2.0.14':
+                if (!DBUtil::changeTable('agoraportal_queues'))
+                    return false;
             /* IMPORTANT: DBUtil::changeTable elimina els índexos. Cal
              * afegir una comprovació amb DBUtil::metaIndexes per saber
              * si s'han de tornar a crear. */

--- a/html/portal/modules/Agoraportal/lib/Agoraportal/Version.php
+++ b/html/portal/modules/Agoraportal/lib/Agoraportal/Version.php
@@ -12,7 +12,7 @@ class Agoraportal_Version extends Zikula_AbstractVersion {
         $meta['displayname'] = $this->__("Agoraportal");
         $meta['description'] = $this->__("Administració dels serveis d'Àgora, petició d'espais nous i gestió per part dels centres.");
         $meta['url'] = $this->__("Agoraportal");
-        $meta['version'] = '2.0.13';
+        $meta['version'] = '2.0.14';
         $meta['securityschema'] = array('Agoraportal::' => '::');
         return $meta;
     }

--- a/html/portal/modules/Agoraportal/tables.php
+++ b/html/portal/modules/Agoraportal/tables.php
@@ -531,7 +531,7 @@ function Agoraportal_tables() {
         'description' => "X NOTNULL DEFAULT ''",
         'userCommentsText' => "X NOTNULL DEFAULT ''");
 
-    
+
     // agoraportal_modelTypes table definition
     $table['agoraportal_modelTypes'] = DBUtil::getLimitedTablename('agoraportal_modelTypes');
     $table['agoraportal_modelTypes_column'] = array('modelTypeId' => 'modelTypeId',
@@ -636,7 +636,7 @@ function Agoraportal_tables() {
         'timeCreated' => "I(20)",
         'timeStart' => "I(20)",
         'timeEnd' => "I(20)",
-        'params' => "C(255) NOTNULL DEFAULT ''",
+        'params' => "X NOTNULL DEFAULT ''",
         'logId' => "I NOTNULL DEFAULT '0'"
     );
 


### PR DESCRIPTION
Per provar-ho caldrà executar una operació amb molts paràmeters posant continguts molt llargs , si el json ja supera els 255 caràcters hi ha suficient. A la pàgina de cues no s'han de poder veure els paràmetres de la operació pq el json no serà correcte.

Aquest patch fa el camp més llarg de manera que s'elimina aquest error (en les operacions afegides a partir de la seva aplicació).