### PR TITLE
Added first version of monitor.php

### DIFF
--- a/html/.htaccess-dist
+++ b/html/.htaccess-dist
@@ -12,6 +12,7 @@ RewriteRule ^opcache(.*)$ - [L]
 RewriteRule ^testapp(.*)$ - [L]
 RewriteRule ^index(.*)$ - [L]
 RewriteRule ^CHANGES(.*)$ - [L]
+RewriteRule ^monitor(.*)$ - [L]
 
 # Required for the proper functioning of cacti
 RewriteRule ^server-status$ - [L]

--- a/html/CHANGES.txt
+++ b/html/CHANGES.txt
@@ -5,6 +5,9 @@ development home at https://github.com/projectestac/agora
 
 Changes in progress
 ---------------------------------------------------------------------------------------
+GENERAL:
+- Added first version of the monitor in testlib
+
 PORTAL
 - Agoraportal: Changed replace_url to support only a single URL (Trello #1027)
 - Agoraportal: Reset table agoraportal_modelTypes (Trello #1027)

--- a/html/monitor.php
+++ b/html/monitor.php
@@ -1,0 +1,4 @@
+<?php
+
+define('APP', 'agora');
+require_once('testlib/monitor.php');


### PR DESCRIPTION
Tan per fer les proves com a l'hora de fer el desplegament a la resta d'entorns, s'ha de fer un canvi al .htaccess perquè es carregui la pàgina monitor.php. El .htaccess-dist de la branca ja conté aquests canvis i, per tant, reemplaçant a la MV el .htaccess pel .htaccess-dist, hauria de funcionar.

Per validar el funcionament d'aquesta part, cal accedir a l'URL http://url_aplicacio/monitor.php i confirmar que retorna una pàgina en blanc amb el text "OK".
