### PR TITLE
GENERAL: URL of the services used to call the crons take into account…

### DIFF
--- a/html/config/createSchoolsListsFiles.php
+++ b/html/config/createSchoolsListsFiles.php
@@ -108,8 +108,20 @@ if (isset($args['update'])) {
         $schools = getServices(false, 'activedId', 'asc', $service['name'], '1');
 
         $schoolsvar = '';
+
         foreach ($schools as $school) {
-            $schoolsvar .= $agora['server']['html'] . $school['dns'] . $service['url'];
+            // Select the server name according to the
+            switch ($school['type']) {
+                case SERVEI_EDUCATIU_ID:
+                    $schoolsvar .= $agora['server']['se-url'] . $agora['server']['base'];
+                    break;
+                case PROJECTES_TYPE_ID:
+                    $schoolsvar .= $agora['server']['projectes'] . $agora['server']['base'];
+                    break;
+                default:
+                    $schoolsvar .= $agora['server']['server'] . $agora['server']['base'];
+            }
+            $schoolsvar .= $school['dns'] . $service['url'];
         }
 
         saveVarToFile($service['file'], $schoolsvar);


### PR DESCRIPTION
… the type of service

This script: http://agora-virtual.xtec.cat/agora/config/createSchoolsListsFiles.php generates a list of URL to be called by the cron. The server part of the URL must vary according to the type of service.

Examples:
http://agora-virtual.xtec.cat/agora/centre-6/wp-cron.php
http://agora-virtual.xtec.cat/agora/centre-7/wp-cron.php
http://agora-virtual-se.xtec.cat/agora/centre-8/wp-cron.php
http://agora-virtual-projectes.xtec.cat/agora/centre-9/wp-cron.php 